### PR TITLE
Updated actions/checkout@v3 to actions/checkout@v4

### DIFF
--- a/.github/workflows/redo-typo-pr.yml
+++ b/.github/workflows/redo-typo-pr.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updated actions/checkout@v3 to actions/checkout@v4

https://github.com/actions/checkout/releases/tag/v4.2.2

This is the only file in the repository that was still using the old version (v3). Updating it ensures consistency and up-to-date security across all workflows.