### PR TITLE
update GitHub actions in CI workflows 

### DIFF
--- a/.github/workflows/redo-typo-pr.yml
+++ b/.github/workflows/redo-typo-pr.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0