### PR TITLE
fix: python rounding

### DIFF
--- a/docs/fees/notebook/fee-model.py
+++ b/docs/fees/notebook/fee-model.py
@@ -546,7 +546,7 @@ def _(
             A bit of magic for the fake exponential and integer math. Computing the divisor this way should ensure
             that the multiplier will increase by at most a factor of ~ 1.125 every block.
             """
-            return Uint256(int(self.mana_target.value / 0.117))
+            return Uint256((self.mana_target.value * 854_700_854) // 100_000_000)
 
         def compute_sequencer_costs(
             self, block: Optional[Block], real=False

--- a/docs/fees/notebook/fee-model.py
+++ b/docs/fees/notebook/fee-model.py
@@ -820,9 +820,9 @@ def _(
     random,
 ):
     fee_model = FeeModel(
-        mana_target=Uint256(int(1e8)),
-        l1_gas_per_block_proposed=Uint256(int(0.3e6)),
-        l1_gas_per_epoch_verified=Uint256(int(1e6)),
+        mana_target=Uint256(int(75_000_000)),
+        l1_gas_per_block_proposed=Uint256(int(300_000)),
+        l1_gas_per_epoch_verified=Uint256(int(3_600_000)),
         proving_cost_per_mana=Uint256(int(WEI_PER_MANA)),
         l1_gas_oracle=L1GasOracle(
             pre=L1Fees(blob_fee=Uint256(1), base_fee=Uint256(int(1e9))),


### PR DESCRIPTION
The `fee_update_fraction` uses `0.117` directly since it was working in python, but due to rounding this meant that it could hit one-off values compared to the integer math variant. The versions are now aligned between the solidity and python to use integer maths for this value.

Also updates the epoch verification cost to 3.6M.